### PR TITLE
Use the existing "ActiveTheme" in cookies as the default selected theme in ThemeSwitcherItem

### DIFF
--- a/CS/switcher/switcher/ThemeSwitcher/ThemeJsChangeDispatcher.cs
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeJsChangeDispatcher.cs
@@ -50,8 +50,20 @@ public class ThemeJsChangeDispatcher : ComponentBase, IThemeChangeRequestDispatc
         _pendingTheme = null;
     }
 
-    public async ValueTask DisposeAsync() {
-        if(_module != null)
-            await _module.DisposeAsync();
+    //https://stackoverflow.com/questions/72488563/blazor-server-side-application-throwing-system-invalidoperationexception-javas
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_module != null)
+            {
+                await _module.DisposeAsync();
+            }
+            GC.SuppressFinalize(this);
+        }
+        catch (JSDisconnectedException ex)
+        {
+            // Ignore
+        }
     }
 }

--- a/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcher.razor
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcher.razor
@@ -1,6 +1,6 @@
 ﻿@inject ThemeService Themes
 @rendermode InteractiveServer
-<ThemeJsChangeDispatcher InitialThemeName="blazor-berry"></ThemeJsChangeDispatcher>
+<ThemeJsChangeDispatcher InitialThemeName="@InitialThemeName"></ThemeJsChangeDispatcher>
 <div class="@GetHeaderContainerCss()">
     <div class="btn-container d-flex">
         <DxButton Click="@ToggleThemeSwitcherPanel" CssClass="@GetThemeSwitcherCssClass()" SizeMode="SizeMode.Large"
@@ -14,6 +14,10 @@
 </div>
 
 @code {
+    [Inject]
+    private Microsoft.AspNetCore.Http.IHttpContextAccessor HttpContextAccessor { get; set; }
+    private string? InitialThemeName { get; set; } = "blazor-berry";
+
     string _themeName;
     bool _themeSwitcherShown;
 
@@ -39,7 +43,8 @@
         }
     }
     protected override void OnInitialized() {
-        ThemeName = Themes.ActiveTheme?.Name ?? string.Empty;
+        InitialThemeName = HttpContextAccessor.HttpContext?.Request.Cookies["ActiveTheme"] ?? InitialThemeName;
+        ThemeName = InitialThemeName ?? string.Empty;
     }
     void ToggleThemeSwitcherPanel() {
         ThemeSwitcherShown = !ThemeSwitcherShown;

--- a/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcher.razor
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcher.razor
@@ -16,7 +16,7 @@
 @code {
     [Inject]
     private Microsoft.AspNetCore.Http.IHttpContextAccessor HttpContextAccessor { get; set; }
-    private string? InitialThemeName { get; set; } = "blazor-berry";
+    private string? InitialThemeName { get; set; } = "blazing-berry";
 
     string _themeName;
     bool _themeSwitcherShown;

--- a/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcherContainer.razor
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcherContainer.razor
@@ -10,7 +10,7 @@
                 @foreach(var themeSet in Themes.ThemeSets) {
                     <span class="themeswitcher-group card-header list-group-item">@themeSet.Title</span>
                     @foreach(var theme in themeSet.Themes) {
-                        <ThemeSwitcherItem Theme="@theme" Click="ThemeSwitcherItem_Click"/>
+                        <ThemeSwitcherItem Theme="@theme" ActiveThemeName="@ThemeName" Click="ThemeSwitcherItem_Click" />
                     }
                 }
             </div>

--- a/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcherItem.razor
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeSwitcherItem.razor
@@ -1,13 +1,14 @@
 ﻿@inject ThemeService Themes
 @rendermode InteractiveServer
 
-<a class="themeswitcher-item list-group-item list-group-item-action @Theme.GetCssClass(Themes.ActiveTheme == Theme) @Theme.IconCssClass"
+<a class="themeswitcher-item list-group-item list-group-item-action @Theme.GetCssClass(ActiveThemeName == Theme.Name) @Theme.IconCssClass"
    @onclick:preventDefault
    @onclick="Anchor_Click">
     <span>@Theme.Title</span>
 </a>
 @code {
     [Parameter] public Theme Theme { get; set; }
+    [Parameter] public string ActiveThemeName { get; set; }
     [Parameter] public EventCallback<Theme> Click { get; set; }
 
     async Task Anchor_Click() {


### PR DESCRIPTION
Use the existing "ActiveTheme" in cookies as the default selected theme in ThemeSwitcherItem，otherwise the "blazing berry" is always selected as default after a restart.
![image](https://github.com/user-attachments/assets/c591b70e-963e-4691-892b-d1e413171500)
