### PR TITLE
fix: caught exception that appears on the page reloading

### DIFF
--- a/CS/switcher/switcher/ThemeSwitcher/ThemeJsChangeDispatcher.cs
+++ b/CS/switcher/switcher/ThemeSwitcher/ThemeJsChangeDispatcher.cs
@@ -51,7 +51,10 @@ public class ThemeJsChangeDispatcher : ComponentBase, IThemeChangeRequestDispatc
     }
 
     public async ValueTask DisposeAsync() {
-        if(_module != null)
-            await _module.DisposeAsync();
+        try {
+            if(_module != null)
+                await _module.DisposeAsync();
+        } catch(JSDisconnectedException) {
+        }
     }
 }


### PR DESCRIPTION
Fixed: T1263076 - Theme Switcher for Blazor - Exception is thrown after reloading the page
https://isc.devexpress.com/internal/ticket/details/T1263076

Official documentation: https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?view=aspnetcore-6.0#javascript-isolation-in-javascript-modules